### PR TITLE
New template 'av-bibtex'

### DIFF
--- a/documentation/index.html
+++ b/documentation/index.html
@@ -226,7 +226,10 @@ The second way of using this plug-in (new to papercite), is to use bibcite and b
   <ul>
     <li><code>default-bibtex</code> is the default template used for the
   <code>bibtex</code> command</li>
-    <li><code>default-bibshow</code> is he default template used for the
+    <li><code>av-bibtex</code> is another template for the <code>bibtex</code> command. It adds
+  support for <code>abstract</code> field (toggled like the bibtex entry), explicit
+  <code>doi:</code> link and a <em>Download PDF</em> link for <code>url</code> field.
+    <li><code>default-bibshow</code> is the default template used for the
   <code>bibshow</code> command</li>
     </ul>
     

--- a/readme.txt
+++ b/readme.txt
@@ -89,6 +89,7 @@ subfolders tpl (citation list rendering) and format (entry rendering).
 
 = HEAD =
   * New style "plain" (thanks to Andrius Velykis)
+  * New template "av-bibtex" (thanks to Andrius Velykis)
   * Improved compatibility with the highlight plugin (thanks to Andrius Velykis)
 = 0.3.21 =
   * Fixed issue #26 (newlines stripped from bibtex)

--- a/tpl/av-bibtex.tpl
+++ b/tpl/av-bibtex.tpl
@@ -1,0 +1,29 @@
+@{group@
+@?groupkey@
+<h3 class="papercite">@groupkey@</h3>
+@;groupkey@
+<ul class="papercite_bibliography">
+@{entry@
+<li>
+	@#entry@
+	@?doi@
+	<a href='http://dx.doi.org/@doi@' class='papercite_doi' title='View on publisher site'>doi:@doi@</a>
+	@;doi@
+	<br/>
+	<a href="javascript:void(0)" id="papercite_@papercite_id@" class="papercite_toggle">[BibTeX]</a>
+	@?abstract@
+	<a href="javascript:void(0)" id="papercite_abstract_@papercite_id@" class="papercite_toggle">[Abstract]</a>
+	@;abstract@
+	@?url@
+	<a href="@url@" title='Download PDF' class='papercite_pdf'>[Download PDF]</a>
+	@;url@
+	@?abstract@
+	<blockquote class="papercite_bibtex" id="papercite_abstract_@papercite_id@_block">@abstract@</blockquote>
+	@;abstract@
+	<div class="papercite_bibtex" id="papercite_@papercite_id@_block">
+		<pre><code class="tex bibtex">@bibtex@</code></pre>
+	</div>
+</li>
+@}entry@
+</ul>
+@}group@


### PR DESCRIPTION
Adding a template 'av-bibtex', which I have created for my website. It is an adaptation of 'default-bibtex': adds support for "abstract" field (toggled like the bibtex link). Also using explicit text links instead of icons for DOI (e.g. doi:XXX-XXX as the link text) and URL ("Download PDF" for URL).

I am using "Download PDF" for URL field with the assumption that it always points to a PDF - this way if someone copies the bibtex entry, they automatically get a reference to where the PDF is available. However, this requires the fields to be set explicitly in bibtex (as opposed to the automatic PDF links based on the key in papercite).

Do you think its useful to bundle different templates (as this one)? Or would you just bundle the default one and have everyone adapt their own themselves? If it is the latter, feel free to reject the pull request.

Thanks for accepting the previous commits. Excellent plugin!
