### PR TITLE
Fix for Issue #35

### DIFF
--- a/bib2tpl/bibtex_converter.php
+++ b/bib2tpl/bibtex_converter.php
@@ -516,7 +516,7 @@ class BibtexConverter
           $entryTpl = &$this->_entry_template->get($type);
           //print "<div><b>$type</b>: ". htmlentities($entryTpl). "</div>";
           $t=  preg_replace_callback(BibtexConverter::$mainPattern, array($this, "_callback"), $entryTpl) . $match[2];
-        } 
+        }
         else $t = "<span style='color:red'>Unknown bibtex entry with key [".$this->_entry["cite"] ."]</span>" . $match[2];
       return $t;
     }
@@ -556,7 +556,12 @@ class BibtexConverter
     if ($count)
       return $this->_entry_template->count($v);
 
-    return $this->_entry_template->format($v);
+    $str = $this->_entry_template->format($v);
+    if ($name != 'bibtex')
+      // replace newlines with spaces, to avoid PHP converting them to <br/>
+      $str = preg_replace("/[\r\n]+/", " ", $str);
+
+    return $str;
   }
 
 


### PR DESCRIPTION
I believe this should suitably fix Issue #35 regarding new lines in wrapped BibTeX entries being converted to <br /> tags on output, without also reopening Issue #26 -- new lines are not replaced in the raw BibTeX code.

The only issue that I see with this is that some fields, such as "abstract", may deliberately have new lines for separate paragraphs that should be preserved. Ideally, perhaps only single new lines, and not several consecutive new lines, might be replaced with spaces, but I've not found a nice way of doing this.
