### PR TITLE
Add "Auto bibshow" and "Skip for post lists" options

### DIFF
--- a/papercite.php
+++ b/papercite.php
@@ -112,11 +112,11 @@ class Papercite {
   static $bibtex_parsers = array("pear" => "Pear parser", "osbib" => "OSBiB parser");
 
   // Names of the options that can be set
-  static $option_names = array("format", "timeout", "file", "bibshow_template", "bibtex_template", "bibtex_parser", "use_db", "auto_bibshow");
+  static $option_names = array("format", "timeout", "file", "bibshow_template", "bibtex_template", "bibtex_parser", "use_db", "auto_bibshow", "skip_for_post_lists");
 
   static $default_options = 
 	array("format" => "ieee", "group" => "none", "order" => "desc", "sort" => "none", "key_format" => "numeric",
-	      "bibtex_template" => "default-bibtex", "bibshow_template" => "default-bibshow", "bibtex_parser" => "pear", "use_db" => false, "auto_bibshow" => false);
+	      "bibtex_template" => "default-bibtex", "bibshow_template" => "default-bibshow", "bibtex_parser" => "pear", "use_db" => false, "auto_bibshow" => false, "skip_for_post_lists" => false);
   /**
    * Init is called before the first callback
    */
@@ -671,6 +671,11 @@ function &papercite_cb($myContent) {
   }
     
   //  print "<div style='border: 1pt solid blue'>";  print(nl2br(htmlentities($myContent)));  print "</div>";
+
+  // (0) Skip processing on this page?
+  if ($papercite->options['skip_for_post_lists'] && !is_single() && !is_page()) {
+    return preg_replace("/\[\s*((?:\/)bibshow|bibshow|bibcite|bibtex)(?:\s+([^[]+))?]/", '', $myContent);
+  }
 
   // (1) First phase - handles everything but bibcite keys
   $text = preg_replace_callback("/\[\s*((?:\/)bibshow|bibshow|bibcite|bibtex)(?:\s+([^[]+))?]/",

--- a/papercite_options.php
+++ b/papercite_options.php
@@ -69,6 +69,7 @@ function papercite_admin_init(){
   add_settings_field('bibtex_parser', 'Bibtex parser', 'papercite_bibtex_parser', 'papercite', 'papercite_choices');
   add_settings_field('use_db', 'Database', 'papercite_use_db', 'papercite', 'papercite_choices');
   add_settings_field('auto_bibshow', 'Auto bibshow', 'papercite_auto_bibshow', 'papercite', 'papercite_choices');
+  add_settings_field('skip_for_post_lists', 'Skip for post lists', 'papercite_skip_for_post_lists', 'papercite', 'papercite_choices');
 }
 
 function papercite_section_text() {
@@ -182,6 +183,11 @@ function papercite_auto_bibshow() {
   echo "<input id='papercite_auto_bibshow' name='papercite_options[auto_bibshow]' type='checkbox' value='1' " . checked(true, $options['auto_bibshow'], false) . " /><p>This will automatically insert [bibshow] (with default settings) when an unexpected [bibcite] is found.</p>";
 }
 
+function papercite_skip_for_post_lists() {
+  $options = $GLOBALS["papercite"]->options;
+  echo "<input id='papercite_skip_for_post_lists' name='papercite_options[skip_for_post_lists]' type='checkbox' value='1' " . checked(true, $options['skip_for_post_lists'], false) . " /><p>This will skip papercite processing when displaying a list of posts or pages. [bibcite] and [bibshow] tags will be stripped.</p>";
+}
+
 function papercite_set(&$options, &$input, $name) {
   if (array_key_exists($name, $input)) {
     $options[$name] = trim($input[$name]);
@@ -195,7 +201,8 @@ function papercite_options_validate($input) {
 
   $options['use_db'] = $input['use_db'] == "yes";
   $options['auto_bibshow'] = $input['auto_bibshow'] == "1";
-      
+  $options['skip_for_post_lists'] = $input['skip_for_post_lists'] == "1";
+
   $options['file'] = trim($input['file']);
   $options['timeout'] = trim($input["timeout"]);
   


### PR DESCRIPTION
- Auto bibshow: If enabled, automatically inserts [bibshow](with default settings) when an unexpected [bibcite] is encountered.
- Skip for post lists: Allows the user to skip papercite processing on pages where multiple posts or pages are shown. In this case, papercite tags are stripped and ignored.
