### PR TITLE
use WP_PLUGIN_URL instead of wpurl for .js register

### DIFF
--- a/papercite.php
+++ b/papercite.php
@@ -901,12 +901,12 @@ function papercite_init() {
   global $papercite;
 
   if (function_exists('wp_enqueue_script')) {
-    wp_register_script('papercite', WP_PLUGIN_URL . '/papercite/js/papercite.js', array('jquery'));
+    wp_register_script('papercite', plugins_url('papercite/js/papercite.js'), array('jquery'));
     wp_enqueue_script('papercite');
   }
 
   // Register and enqueue the stylesheet
-  wp_register_style('papercite_css', WP_PLUGIN_URL . '/papercite/papercite.css' );
+  wp_register_style('papercite_css', plugins_url('papercite/papercite.css'));
   wp_enqueue_style('papercite_css');
 
   // Initialise the object


### PR DESCRIPTION
Papercite's .js didn't register correctly for me - my plugins dir is outside of the wordpress dir.  This change is just to use the WP_PLUGIN_URL path (like it's already doing for the CSS on line 909).
