### PR TITLE
remove comma in front of year for techreport in IEEE template

### DIFF
--- a/format/ieee.tpl
+++ b/format/ieee.tpl
@@ -76,7 +76,7 @@
 </format>
 
 <format types="techreport">
-@?author@@author@, @;@@?title@&quot;@title@,&quot; @;@@?institution@@institution@@;@@?address@, @address@@;@@?type||number@, @:@@;@@?type@@type@ @;@@?number@@number@@;@@?type||number@, @:@@;@@?date@@date@ @;@@?year@, @year@@;@.
+@?author@@author@, @;@@?title@&quot;@title@,&quot; @;@@?institution@@institution@@;@@?address@, @address@@;@@?type||number@, @:@@;@@?type@@type@ @;@@?number@@number@@;@@?type||number@, @:@@;@@?date@@date@ @;@@?year@ @year@@;@.
 </format>
 
 </formats>


### PR DESCRIPTION
When using the IEEE template, techreports have a second comma in front of the year entry. The attached commit fixes this issue and results in a non-erroneous output (compare with inproceedings to see the intended behavior).
