### PR TITLE
Add ability to have HTML formatted strings in bibtex, and add title parameter:

### DIFF
--- a/bib2tpl/bibtex_converter.php
+++ b/bib2tpl/bibtex_converter.php
@@ -567,10 +567,13 @@ class BibtexConverter
       return $this->_entry_template->count($v);
 
     $str = $this->_entry_template->format($v);
-    if ($name != 'bibtex')
+    if ($name != 'bibtex') {
       // replace newlines with spaces, to avoid PHP converting them to <br/>
       $str = preg_replace("/[\r\n]+/", " ", $str);
+    }
+    if ($modifier != 'html') {
       $str = htmlspecialchars($str);
+    }
     return $str;
   }
 
@@ -579,5 +582,3 @@ class BibtexConverter
 
 
 }
-
-?>

--- a/bib2tpl/bibtex_converter.php
+++ b/bib2tpl/bibtex_converter.php
@@ -575,9 +575,7 @@ class BibtexConverter
     }
     if ($modifier != 'html') {
       $str = htmlspecialchars($str);
-<<<<<<< HEAD
     }
-=======
       
     // highlight authors
 	if ($name == 'author' || $name == 'editor') {
@@ -586,12 +584,9 @@ class BibtexConverter
 	  }
 	}
       
->>>>>>> origin/master
     return $str;
   }
 
-
-  
 
 
 }

--- a/bib2tpl/bibtex_converter.php
+++ b/bib2tpl/bibtex_converter.php
@@ -541,6 +541,7 @@ class BibtexConverter
     // --- Get the options
     $v = null;
     $count = false;
+    $modifier = "";
 
     if ($name[0] == "#") {
       $name = substr($name,1);

--- a/documentation/index.html
+++ b/documentation/index.html
@@ -396,6 +396,7 @@ The second way of using this plug-in (new to papercite), is to use bibcite and b
     <ul>
       <li><code>@WP_PLUGIN_URL@</code> will be replaced by the plugin URL.</li>
       <li><code>@papercite_id@</code> is a unique id within the page/post</li>
+      <li><code>@papercite_title@</code> is the title sanitized for use in code or urls. It is sanitized with <code><a href="http://codex.wordpress.org/Function_Reference/sanitize_title">sanitize title()</a></code>, specifically, HTML and PHP tags are stripped.</li>
       <li><code>@key@</code> is a the key as formatted with <code>key_format</code>.</li>
       <li><code>@pdf@</code> is the URL to the auto-detected PDF (or
     to the URL specified in the PDF field).</li>
@@ -417,6 +418,13 @@ The second way of using this plug-in (new to papercite), is to use bibcite and b
      bib2tpl: you can use the operators <code>&gt;</code>,
      <code>&lt;</code>, <code>=</code> and <code>||</code> with the
        same semantics as in main programming languages.
+       </li>
+       <li>
+       All fields are stripped for html code by default, this behaviour can be disabled in the template on a field by field basis by adding the modifier <code>:html</code> to the field.<br>I.e. an abstract field that contains <code>This is the &lt;b&gt;greatest&lt;/b&gt; book in the world</code> will show:
+       <ul>
+       <li><code>@abstract@</code> = This is the greatest book in the world</li>
+       <li><code>@abstract:html@</code> = This is the <b>greatest</b> book in the world</li>
+       </ul><br><b>This should only be used when with fully trusted bibtex sources, as it can be used to embed malicious code on the website</b>
        </li>
        </ul>
     </p>

--- a/papercite.php
+++ b/papercite.php
@@ -866,8 +866,10 @@ class Papercite {
     if ($refs) {
       foreach($refs as &$entry) {
         $entry["papercite_id"] = $this->counter++;
+		$entry["papercite_title"] = sanitize_title($entry["title"]);
       }
     }
+	
 
     // Convert (also set the citation key)
     $bib2tpl = new BibtexConverter($options, $main, $bibtexEntryTemplate);


### PR DESCRIPTION
Use modifier: ":html" so @abstract@ strips html, and @abstract:html@ retains html in the abstract.

Additionally add the variable @papercite_title@ for a stripped version of the title for use in pretty id's (sample: http://ecomerc.com/about-us/publications/#organizational-design-a-step-by-step-approach)