### PR TITLE
Ensure that cache directory will always be writable.

### DIFF
--- a/papercite.php
+++ b/papercite.php
@@ -125,8 +125,8 @@ class Papercite {
   function getCached($url, $timeout = 3600, $sslverify = false) {
     // check if cached file exists
     $name = strtolower(preg_replace("@[/:]@","_",$url));
-    $dir = plugin_dir_path(dirname(__FILE__)) . "/papercite/cache";
-    $file = "$dir/$name.bib";
+    $dir_path = self::getCacheDirectory( 'path' );
+    $file = "$dir_path/$name.bib";
 
     // check if file date exceeds 60 minutes   
     if (! (file_exists($file) && (filemtime($file) + $timeout > time())))  {
@@ -145,8 +145,8 @@ class Papercite {
 
       // Everything is OK: retrieve the body of the HTTP answer
       $body = wp_remote_retrieve_body($req);
-      if (!file_exists($dir)) {
-        mkdir($dir);
+      if (!file_exists($dir_path)) {
+        mkdir($dir_path);
       }
       
       if ($body) {
@@ -164,8 +164,10 @@ class Papercite {
         return false;
       }
     }
-  
-    return array($file, plugins_url()."/papercite/cache/$name");
+
+    $dir_url = self::getCacheDirectory( 'url' );
+
+    return array($file, $dir_url . '/' . $name);
   }
 
   static $bibtex_parsers = array("pear" => "Pear parser", "osbib" => "OSBiB parser");
@@ -225,7 +227,20 @@ class Papercite {
       
   
     }
-    
+
+  }
+
+  /**
+   * Get a writeable directory for caching remote bibtex files.
+   *
+   * @param string $type 'path' for local filepath, or 'url' for URL.
+   * @return string
+   */
+  static function getCacheDirectory( $type = 'dir' ) {
+    $uploads_dir = wp_upload_dir();
+
+    $base = 'url' === $type ? $uploads_dir['baseurl'] : $uploads_dir['basedir'];
+    return apply_filters( 'papercite_cache_directory', $base . '/papercite-cache' );
   }
 
   

--- a/tests/test-remote.php
+++ b/tests/test-remote.php
@@ -4,12 +4,20 @@ require_once dirname(__FILE__) . '/common.inc.php';
 
 class RemoteTest extends PaperciteTestCase {
 
-    function testRemote() {
-        $cachedir = dirname(dirname(__FILE__)) . "/cache";
+    public function setUp() {
+	parent::setUp();
+
+	$cachedir = Papercite::getCacheDirectory();
         foreach(glob("$cachedir/*") as $file) {
-            unlink($file);
+          unlink($file);
         }
 
+	if ( file_exists( $cachedir ) ) {
+          rmdir( $cachedir );
+	}
+    }
+
+    function testRemote() {
         $this->test();
     }
 
@@ -30,5 +38,29 @@ class RemoteTest extends PaperciteTestCase {
         $this->assertRegExp("#Piwowarski#", $text);
     }
 
+    public function testGetCachedShouldCreateCacheDirectory() {
+	$cachedir = Papercite::getCacheDirectory();
+
+	$p = new Papercite();
+        $url = "https://gist.githubusercontent.com/bpiwowar/9793f4e2da48dfb34cde/raw/5fbff41218107aa9dcfab4fc53fe8e2b86ea8416/test.bib";
+	$cached = $p->getCached( $url );
+
+	$this->assertNotEmpty( $cached );
+	$this->assertTrue( file_exists( $cachedir ) );
+    }
+
+    public function testGetCachedShouldCreateLocalCopyOfRemoteFile() {
+	$cachedir = Papercite::getCacheDirectory();
+
+	$p = new Papercite();
+        $url = "https://gist.githubusercontent.com/bpiwowar/9793f4e2da48dfb34cde/raw/5fbff41218107aa9dcfab4fc53fe8e2b86ea8416/test.bib";
+	$cached = $p->getCached( $url );
+
+        $name = strtolower(preg_replace("@[/:]@","_",$url));
+
+	$this->assertNotEmpty( $cached );
+	$this->assertTrue( file_exists( $cached[0] ) );
+	$this->assertTrue( file_exists( $cachedir . '/' . $name . '.bib' ) );
+    }
 }
 


### PR DESCRIPTION
Papercite currently caches remote bibtex file in the 'cache' subdirectory of the `papercite` plugin directory. This is not a reliable technique, as the plugin directory is not guaranteed to be writable by the webserver. It's better to use a guaranteed-writable location, like that provided by `wp_upload_dir()`.