### PR TITLE
Remove curly braces for the fields "location" and "publisher"

### DIFF
--- a/lib/BibTex_osbib.php
+++ b/lib/BibTex_osbib.php
@@ -642,7 +642,7 @@ class PaperciteBibTexEntries {
     }
 
     // Remove braces and handles capitalization
-    foreach(array("title","booktitle", "journal") as $f)
+    foreach(array("title", "booktitle", "journal", "publisher", "location") as $f)
       if (in_array($f, array_keys($ret))) 
 	$ret[$f] = $this->formatTitle($ret[$f]);
     


### PR DESCRIPTION
Curly braces are often used to protect uppercase formats in the fields `"location"` and `"publisher"` and can be removed using the function `formatTitle()`. A short fix is to iterate over these fields in the `foreach`-loop.