### PR TITLE
fix regex for PHP7.3

### DIFF
--- a/papercite.classes.php
+++ b/papercite.classes.php
@@ -650,7 +650,7 @@ class Papercite
         // Get all the options pairs and store them
         // in the $options array
         $options_pairs = array();
-        preg_match_all("/\s*([\w-:_]+)=(?:([^\"]\S*)|\"([^\"]+)\")(?:\s+|$)/", sizeof($matches) > 2 ? $matches[2] : "", $options_pairs, PREG_SET_ORDER);
+        preg_match_all("/\s*([\w\-:_]+)=(?:([^\"]\S*)|\"([^\"]+)\")(?:\s+|$)/", sizeof($matches) > 2 ? $matches[2] : "", $options_pairs, PREG_SET_ORDER);
 
 
         // print "<pre>";


### PR DESCRIPTION
The hyphen needs to be escaped when it used as a literal in a regex in PHP7.3.