### PR TITLE
first author if present else first editor if present

### DIFF
--- a/bib2tpl/bibtex_converter.php
+++ b/bib2tpl/bibtex_converter.php
@@ -262,6 +262,7 @@ class BibtexConverter
         $id = 0;
         foreach ($data as &$entry) {
             $entry['firstauthor'] = isset($entry['author']->authors) ? $entry['author']->authors[0]["surname"] : "";
+            $entry['firstauthoreditor'] = isset($entry['author']->creators[0]["surname"]) ? $entry['author']->creators[0]["surname"] : ( isset($entry['editor']->creators[0]["surname"]) ? $entry['editor']->creators[0]["surname"] : "");
             $entry['entryid'] = $id++;
         }
     }


### PR DESCRIPTION
I would propose a change to output `first author` if present else `first editor` if present.

As mentioned in #116 (and forgotten so long, till an update broke my own crude changes : ) ) sometimes there are publications, where we want to acknowledge the editorship of a work, without the need to fill the `author` field.

For this to work, we could have a new entry `firsteditorauthor` (or any better name), that gives the first author where possible, or in case of nil it would search for the first editor.

thanks